### PR TITLE
Add typescript definitions

### DIFF
--- a/localize/index.d.ts
+++ b/localize/index.d.ts
@@ -1,0 +1,28 @@
+import localize from './localize';
+
+type Langs =
+  | 'en'
+  | 'ar'
+  | 'cz'
+  | 'de'
+  | 'es'
+  | 'fr'
+  | 'hu'
+  | 'id'
+  | 'it'
+  | 'ja'
+  | 'ko'
+  | 'nb'
+  | 'nl'
+  | 'pl'
+  | 'pt-BR'
+  | 'ru'
+  | 'sk'
+  | 'sv'
+  | 'th'
+  | 'zh'
+  | 'zh-TW';
+
+declare const collection: Record<Langs, typeof localize>;
+
+export default collection;

--- a/localize/localize-definition.jst
+++ b/localize/localize-definition.jst
@@ -1,0 +1,3 @@
+import localize from '../localize';
+
+export default localize;

--- a/localize/localize.d.ts
+++ b/localize/localize.d.ts
@@ -1,3 +1,3 @@
 import Ajv from 'ajv';
 
-export default function localize(errors: Ajv.ErrorObject[]): void;
+export default function localize(errors?: Ajv.ErrorObject[] | null): void;

--- a/localize/localize.d.ts
+++ b/localize/localize.d.ts
@@ -1,0 +1,3 @@
+import Ajv from 'ajv';
+
+export default function localize(errors: Ajv.ErrorObject[]): void;

--- a/scripts/compile-locales.js
+++ b/scripts/compile-locales.js
@@ -9,6 +9,7 @@ var messages = require('../messages')
   , totalMissing = 0;
 
 var localize = getLocalizeTemplate();
+var localizeDefinition = getLocalizeDefinitionTemplate();
 
 messages._locales.forEach(compileMessages);
 console.log('Total missing messages:', totalMissing);
@@ -21,6 +22,10 @@ function compileMessages(locale) {
   code = beautify(code, { indent_size: 2 }) + '\n';
   var targetPath = path.join(localePath, 'index.js');
   fs.writeFileSync(targetPath, code);
+  var definitionCode = localizeDefinition();
+  definitionCode = beautify(definitionCode, { indent_size: 2 }) + '\n';
+  var definitionTargetPath = path.join(localePath, 'index.d.ts');
+  fs.writeFileSync(definitionTargetPath, definitionCode);
 }
 
 
@@ -79,5 +84,11 @@ function byKeyword(a, b) {
 
 function getLocalizeTemplate() {
   var tmplStr = fs.readFileSync(path.join(__dirname, '..', 'localize', 'localize.jst'));
+  return doT.compile(tmplStr);
+}
+
+
+function getLocalizeDefinitionTemplate() {
+  var tmplStr = fs.readFileSync(path.join(__dirname, '..', 'localize', 'localize-definition.jst'));
   return doT.compile(tmplStr);
 }


### PR DESCRIPTION
Add definition files for typescript usage.
I try to pass test but failed with error
```
PhantomJS 2.1.1 (Mac OS X 0.0.0) ERROR: 'This browser lacks typed array (Uint8Array) support which is required by `buffer` v5.x. Use `buffer` v4.x if you require old browser support.'
```
and install `buffer@4` with no success.
Seams all recent pulls failed with same error.
Hope someone knows how to fix it 😄



