### PR TITLE
Added Dutch translations for unevaluated props/items and discriminator

### DIFF
--- a/messages/index.js
+++ b/messages/index.js
@@ -638,6 +638,7 @@ module.exports = {
   },
   unevaluatedProperties: {
     en: "must NOT have unevaluated properties",
+    nl: "mag geen ongecontroleerde eigenschappen bevatten",
     ru: "не должно иметь непроверенных полей",
   },
   unevaluatedItems: {
@@ -645,6 +646,7 @@ module.exports = {
       n: "{{var n = e.params.len;}}",
     },
     en: "{{#def.n}}must NOT have more than {{=n}} item{{#def.mPlural}}",
+    nl: "{{#def.n}}mag niet meer dan {{= n}} item{{#def.mPlural}} bevatten",
     ru: "{{#def.n}}должно иметь не более, чем {{=n}} элемент{{#def.mPlural}}",
   },
   uniqueItems: {

--- a/messages/jtd.js
+++ b/messages/jtd.js
@@ -147,10 +147,12 @@ module.exports = {
     _type: true,
     tag: {
       en: 'tag "{{=e.params.tag}}" must be string',
+      nl: 'tag "{{=e.params.tag}}" moet een tekenreeks zijn',
       ru: 'поле "{{=e.params.tag}}" должно быть строкой',
     },
     mapping: {
       en: 'value of tag "{{=e.params.tag}}" must be in mapping',
+      nl: 'de waarde van het veld "{{= e.params.tag}}" moet voorkomen in de mapping',
       ru: 'значение поля "{{=e.params.tag}}" должно быть ключом одной из схем',
     },
   },


### PR DESCRIPTION
This PR adds Dutch translations for `unevaluatedProperties`, `unevaluatedItems` and `discriminator` messages.