### PR TITLE
Fix type of localize interface

### DIFF
--- a/localize/types.d.ts
+++ b/localize/types.d.ts
@@ -1,5 +1,5 @@
 import {ErrorObject} from "ajv"
 
 export interface Localize {
-  (errors?: null | ErrorObject): void
+  (errors?: null | ErrorObject[]): void
 }


### PR DESCRIPTION
Otherwise the following compiler error is thrown:

> Argument of type 'ErrorObject<string, Record<string, any>, unknown>[] | null | undefined' is not assignable to parameter of type 'ErrorObject<string, Record<string, any>, unknown> | null | undefined'.